### PR TITLE
Don't let mobile toolbars at the bottom impact the background

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -33,7 +33,7 @@ img::-moz-selection {
 .fixed-image {
   position: fixed;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   -webkit-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
 }


### PR DESCRIPTION
The background image will change if you swipe up a bit and bring up the mobile toolbar on browsers